### PR TITLE
Lock ruby version to 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:2.4.0
 MAINTAINER labs-sydney
 
 RUN apt-get update && apt-get install -y postgresql


### PR DESCRIPTION
Postfacto is currently using 2.3.1, but due to the latest push to Docker Hub, the latest container image is using 2.4.0 instead. Moving forward, we should probably lock the ruby version.